### PR TITLE
Add GH action to run Bazel build using RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,3 +39,7 @@ build --action_env=CC
 build --action_env=CXX
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
+
+build:ci --build_metadata=ROLE=CI
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://remote.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -44,3 +44,4 @@ build:ci --build_metadata=ROLE=CI
 build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://remote.buildbuddy.io
 build:ci --remote_cache=grpcs://remote.buildbuddy.io
+build:ci --remote_timeout=3600

--- a/.bazelrc
+++ b/.bazelrc
@@ -43,3 +43,4 @@ build --action_env=PATH
 build:ci --build_metadata=ROLE=CI
 build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://remote.buildbuddy.io
+build:ci --remote_cache=grpcs://remote.buildbuddy.io

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,29 @@
+name: bazel-rbe
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+      branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install bazelisk
+      run: |
+        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
+        mkdir -p "${GITHUB_WORKSPACE}/bin/"
+        mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+        chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+    - name: Build
+      run: |
+        "${GITHUB_WORKSPACE}/bin/bazel" build \
+            --config=ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
   pull_request:
       branches: [ master ]
+      paths-ignore:
+       - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-      branches: [ main ]
+      branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,7 +23,7 @@ jobs:
         chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
     - name: Build
       run: |
-        "${GITHUB_WORKSPACE}/bin/bazel" build \
+        "${GITHUB_WORKSPACE}/bin/bazel" build //:brpc \
             --config=ci \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
             //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,7 +23,7 @@ jobs:
         chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
     - name: Build
       run: |
-        "${GITHUB_WORKSPACE}/bin/bazel" build //:brpc \
+        "${GITHUB_WORKSPACE}/bin/bazel" build \
             --config=ci \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-            //...
+            //:brpc


### PR DESCRIPTION
### What problem does this PR solve?

Makes Bazel builds faster using Remote Build Execute (RBE) and action caching.

Created a new Github Action to build brpc using BuildBuddy which is a service that provides Bazel RBE with caching. This service is free for OSS projects.

### Results
Average Bazel build time with default options decreased from 25m 22s to  1m 17s
